### PR TITLE
Creating a static path for projects ownership page

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -67,6 +67,9 @@ class ExternalModule extends AbstractExternalModule {
                 $this->includeJs('js/my-projects.js');
                 $this->includeCss('css/my-projects.css');
             }
+            elseif ($_GET['action'] == 'project_ownership') {
+                redirect($this->getUrl('plugins/ownership_list.php'));
+            }
         }
 
         if (!empty($context)) {


### PR DESCRIPTION
Implements #17.

Review steps:
- [ ] Access `index.php?action=project_ownership` and make sure you got redirected to Projects Ownership page