### PR TITLE
Add billable and sequestered columns to redcap_entity_types

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -79,6 +79,14 @@ class ExternalModule extends AbstractExternalModule {
                     'name' => 'Owner last name',
                     'type' => 'text',
                 ],
+                'billable' => [
+                    'name' => 'Billable',
+                    'type' => 'integer',
+                ],
+                'sequestered' => [
+                    'name' => 'Sequestered',
+                    'type' => 'integer',
+                ],
             ],
         ];
 

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ This module forces the collection of project ownership information, but it canno
 
 - "Additional Text Toggle": Toggle showing of "Additional Project Ownership Text"
 - "Additional Project Ownership Text": A configurable rich-text field that will be displayed at the end of the Project Ownership portion of the Project Settings menu when creating or modifying a project.
+- "Enable features intended for use at the University of Florida": Enables features intended for use on UF CTSI-IT REDCap instances which are likely not useful for other institutions.

--- a/classes/entity/list/ProjectOwnershipList.php
+++ b/classes/entity/list/ProjectOwnershipList.php
@@ -2,10 +2,13 @@
 
 namespace ProjectOwnership\Entity;
 
+require_once dirname(__DIR__) . '/../../ExternalModule.php';
+
 use RedCapDB;
 use RCView;
 use REDCap;
 use REDCapEntity\EntityList;
+use ProjectOwnership\ExternalModule\ExternalModule;
 
 class ProjectOwnershipList extends EntityList {
 
@@ -120,6 +123,15 @@ class ProjectOwnershipList extends EntityList {
         }
 
         return $query;
+    }
+
+    function setCols($cols) {
+        $EM = new ExternalModule();
+        if ($EM->getSystemSetting('enable_uf_features')) {
+            $cols = array_merge($cols, ['billable', 'sequestered']);
+        }
+
+        return parent::setCols($cols);
     }
 
     function getSortableColumns() {

--- a/classes/entity/list/ProjectOwnershipList.php
+++ b/classes/entity/list/ProjectOwnershipList.php
@@ -128,7 +128,8 @@ class ProjectOwnershipList extends EntityList {
     function setCols($cols) {
         $EM = new ExternalModule();
         if ($EM->getSystemSetting('enable_uf_features')) {
-            $cols = array_merge($cols, ['billable', 'sequestered']);
+            if ($EM->getSystemSetting("show_billable_column")) { array_push($cols, "billable"); }
+            if ($EM->getSystemSetting("show_sequestered_column")) { array_push($cols, "sequestered"); }
         }
 
         return parent::setCols($cols);

--- a/config.json
+++ b/config.json
@@ -49,6 +49,11 @@
                     }
                 ]
             }
+        },
+        {
+            "name": "Enable features intended for use at the University of Florida",
+            "key": "enable_uf_features",
+            "type": "checkbox"
         }
     ],
     "links": {

--- a/config.json
+++ b/config.json
@@ -54,6 +54,34 @@
             "name": "Enable features intended for use at the University of Florida",
             "key": "enable_uf_features",
             "type": "checkbox"
+        },
+        {
+            "name": "Show billable column",
+            "key": "show_billable_column",
+            "type": "checkbox",
+            "branchingLogic": {
+                "conditions":
+                [
+                    {
+                        "field": "enable_uf_features",
+                        "value": true
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Show sequestered column",
+            "key": "show_sequestered_column",
+            "type": "checkbox",
+            "branchingLogic": {
+                "conditions":
+                [
+                    {
+                        "field": "enable_uf_features",
+                        "value": true
+                    }
+                ]
+            }
         }
     ],
     "links": {


### PR DESCRIPTION
Closes #45 

Introduces a new system toggle, "Enable features intended for use at the University of Florida" since other people use this module. Branching logic hides the billable and sequestered toggles (and anything else we might add later that the general public won't care about).