### PR TITLE
Add configurable text field at the system level

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -254,6 +254,14 @@ class ExternalModule extends AbstractExternalModule {
             'value' => $po_data['email'],
         ]));
 
+        // Configurable text field.
+        if ($this->getSystemSetting("additional_text_toggle")) {
+            $output .= RCView::div(
+                ['class' => 'po-row'],
+                $this->getSystemSetting("additional_text")
+            );
+        }
+
         // Fieldset title.
         $output = RCView::td(['class' => 'po-label po-col'], 'Project Ownership') . RCView::td(['class' => 'po-col'], $output);
 

--- a/README.md
+++ b/README.md
@@ -66,3 +66,8 @@ The Project Ownership List is accessible via the custom action, _project\_owners
 ## Backfilling project ownership
 
 This module forces the collection of project ownership information, but it cannot address a long history of missing ownership info.  If some guess as to the ownership is needed, that can be addressed with heuristics that guess at ownership info from the REDCap database.  University of Florida's CTS-IT did this for UF's primary REDCap environment.  The product of that work is available in the form of two SQL files [backfill\_project\_ownership\_test.sql](doc/backfill_project_ownership_test.sql) and [backfill\_project\_ownership.sql](doc/backfill_project_ownership.sql) These files gleen ownership data from the REDCap database using 16 queries of PI, creator, user-authorization, user activity and login data. They produce a reasonable guess of who is likely to care about the data in a project and be available to speak with authority about that data. These files are somewhat specific to UF and would need to be adapted to local requirements before use at other institutions. Specifically, the records in the paid_creators table and some individual project records would have no meaning outside of UF.
+
+## System Level Configuration
+
+- "Additional Text Toggle": Toggle showing of "Additional Project Ownership Text"
+- "Additional Project Ownership Text": A configurable rich-text field that will be displayed at the end of the Project Ownership portion of the Project Settings menu when creating or modifying a project.

--- a/config.json
+++ b/config.json
@@ -30,6 +30,27 @@
             "institution": "University of Florida - CTSI"
         }
     ],
+    "system-settings": [
+        {
+            "name": "Additional Text Toggle",
+            "key": "additional_text_toggle",
+            "type": "checkbox"
+        },
+        {
+            "name": "Additional Project Ownership Text",
+            "key": "additional_text",
+            "type": "rich-text",
+            "branchingLogic": {
+                "conditions":
+                [
+                    {
+                        "field": "additional_text_toggle",
+                        "value": true
+                    }
+                ]
+            }
+        }
+    ],
     "links": {
        "control-center": [
           {


### PR DESCRIPTION
Closes #46 

An image may be helpful in the menu.

It's possible that our usual testing process (i.e. using the 0.0.0 module and not switching versions) may appear to "break" the module, if that occurs, just toggle the new system-level checkbox on and off. I suspect the `undefined` checkbox is not falsy and it's jamming things up on an initial run.