### PR TITLE
Check for definition of USERID at start of buildOwnershipFieldset

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -204,6 +204,7 @@ class ExternalModule extends AbstractExternalModule {
      * Builds ownership fieldset.
      */
     protected function buildOwnershipFieldset($context, $project_id = null) {
+        if (!defined('USERID')) { return; } // prevent error email from unauthorized page load attempts
         // Setting up default values.
         $po_data = [
             'username' => '',


### PR DESCRIPTION
Closes #59 

To recreate the bug, **in a private browsing window** attempt to navigate to any project setup page, e.g. `http://localhost:11414/redcap_v14.1.4/ProjectSetup/index.php?pid=16`. An error message in should appear in mailhog.

I bet this error showed up because people like to bookmark their projects!  
PHP 7 used to just throw a warning for accessing undefined constants.